### PR TITLE
feat(crypto): Add Ethereum signature recovery and hashing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # easy-web3
+
+Go implementation of [https://github.com/labteral/easyweb3](Easy Web3) library.

--- a/easy_web3.go
+++ b/easy_web3.go
@@ -1,11 +1,13 @@
 package easyweb3
 
 import (
-	"math"
 	"math/big"
-	"time"
 
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
@@ -16,8 +18,8 @@ type EasyWeb3 struct {
 
 const (
 	DefaultGas               = 4000000 // 4e6
-	WaitLoopSeconds         = 0.1
-	WaitLogLoopSeconds      = 10
+	WaitLoopSeconds          = 0.1
+	WaitLogLoopSeconds       = 10
 	DefaultConnectionTimeout = 10
 )
 
@@ -49,7 +51,7 @@ func GetRSVFromSignature(signature string) (r, s string, v int64) {
 	// Split signature into components
 	r = signature[:64]
 	s = signature[64:128]
-	
+
 	// Convert v from hex to decimal
 	vHex := signature[128:]
 	vBig := new(big.Int)
@@ -57,4 +59,30 @@ func GetRSVFromSignature(signature string) (r, s string, v int64) {
 	v = vBig.Int64()
 
 	return r, s, v
+}
+
+// RecoverAddress recovers the Ethereum address that signed a given message
+func (ew *EasyWeb3) RecoverAddress(text string, signature []byte) (common.Address, error) {
+	// Create the prefixed hash of the message
+	msg := accounts.TextHash([]byte(text))
+
+	// Recover the public key
+	sigPublicKey, err := crypto.SigToPub(msg, signature)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	// Convert public key to address
+	return crypto.PubkeyToAddress(*sigPublicKey), nil
+}
+
+// Keccak256 returns the Keccak256 hash of the input as a hex string without "0x" prefix
+func Keccak256(input string) string {
+	hash := crypto.Keccak256([]byte(input))
+	return hex.EncodeToString(hash)
+}
+
+// Hash is an alias for Keccak256
+func Hash(input string) string {
+	return Keccak256(input)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/yourusername/easy-web3
+
+go 1.20
+
+require (
+	github.com/ethereum/go-ethereum v1.13.14
+) 


### PR DESCRIPTION
Add RecoverAddress, Keccak256, and Hash functions to match Python implementation:
- RecoverAddress recovers the signing address from message and signature
- Keccak256 computes Keccak-256 hash of input string
- Hash provides an alias for Keccak256

This provides parity with the Python EasyWeb3 implementation while using Go-Ethereum's native crypto functions for better performance.